### PR TITLE
fix(api): unused JDA classes should remain (fixes #37)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,4 +39,4 @@ maven_group = me.axieum.mcmod.minecord
 github_repo = axieum/minecord
 
 # Other
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx1536M

--- a/minecord-api/build.gradle
+++ b/minecord-api/build.gradle
@@ -41,7 +41,7 @@ shadowJar {
     // relocate 'tomp2p.opuswrapper', "${dest}.tomp2p.opuswrapper"
 
     // Minify the result - remove unused classes
-    minimize()
+    // minimize()
 }
 
 // Provide the fat-jar to Fabric's remapping task

--- a/minecord-cmds/src/main/resources/fabric.mod.json
+++ b/minecord-cmds/src/main/resources/fabric.mod.json
@@ -21,9 +21,7 @@
       "me.axieum.mcmod.minecord.impl.cmds.MinecordCommandsImpl"
     ]
   },
-  "mixins": [
-    "minecord-cmds.mixins.json"
-  ],
+  "mixins": [],
   "depends": {
     "java": ">=17",
     "minecraft": "1.19.x",

--- a/minecord-presence/src/main/resources/fabric.mod.json
+++ b/minecord-presence/src/main/resources/fabric.mod.json
@@ -21,9 +21,7 @@
       "me.axieum.mcmod.minecord.impl.presence.MinecordPresenceImpl"
     ]
   },
-  "mixins": [
-    "minecord-presence.mixins.json"
-  ],
+  "mixins": [],
   "depends": {
     "java": ">=17",
     "minecraft": "1.19.x",


### PR DESCRIPTION
We don't know what other modules may or may not use from JDA. In the case of `minecord-cmds`, it was trying to use a `Commands` class that was being pruned from the production mod jar just because the `minecord-api` module wasn't using it.