### PR TITLE
fix(minecord-api): escape special regex characters in StringTemplate

### DIFF
--- a/minecord-api/src/main/java/me/axieum/mcmod/minecord/api/util/StringTemplate.java
+++ b/minecord-api/src/main/java/me/axieum/mcmod/minecord/api/util/StringTemplate.java
@@ -249,7 +249,7 @@ public class StringTemplate
                     if (format != null && !format.isBlank()) {
                         // String
                         if (value instanceof String) {
-                            matcher.appendReplacement(builder, String.format(format, value));
+                            matcher.appendReplacement(builder, Matcher.quoteReplacement(String.format(format, value)));
                         // Number
                         } else if (value instanceof Number) {
                             matcher.appendReplacement(builder, new DecimalFormat(format).format(value));
@@ -277,7 +277,7 @@ public class StringTemplate
                             );
                         // Other
                         } else {
-                            matcher.appendReplacement(builder, String.valueOf(value));
+                            matcher.appendReplacement(builder, Matcher.quoteReplacement(String.valueOf(value)));
                         }
                     }
                 } catch (IllegalArgumentException e) {

--- a/minecord-api/src/test/java/me/axieum/mcmod/minecord/api/util/StringTemplateTests.java
+++ b/minecord-api/src/test/java/me/axieum/mcmod/minecord/api/util/StringTemplateTests.java
@@ -37,6 +37,17 @@ public class StringTemplateTests
     }
 
     @Test
+    @DisplayName("Replace variables with special regex characters")
+    public void variablesWithSpecialCharacters()
+    {
+        st.add("special", "\\$\\\\$$");
+        assertEquals(
+            "_\\$\\\\$$",
+            st.format("_${special}")
+        );
+    }
+
+    @Test
     @DisplayName("Resolve lazy variables")
     public void lazyVariables()
     {


### PR DESCRIPTION
As title. I also added one unit test for this.
Feedback is welcome!

Closes #61.