### PR TITLE
fix(chat): do not check player count during server start-up on Discord messages (fixes #84)

### DIFF
--- a/minecord-chat/src/main/java/me/axieum/mcmod/minecord/impl/chat/util/MinecraftDispatcher.java
+++ b/minecord-chat/src/main/java/me/axieum/mcmod/minecord/impl/chat/util/MinecraftDispatcher.java
@@ -99,7 +99,9 @@ public final class MinecraftDispatcher
     )
     {
         // Fetch the Minecraft server instance, only if there is at least one player logged in
-        Minecord.getInstance().getMinecraft().filter(server -> server.getCurrentPlayerCount() > 0).ifPresent(server ->
+        Minecord.getInstance().getMinecraft().filter(server ->
+            server.getPlayerManager() != null && server.getCurrentPlayerCount() > 0
+        ).ifPresent(server ->
             // Prepare a stream of configured chat entries
             Arrays.stream(getConfig().entries)
                   .parallel()


### PR DESCRIPTION
Fixes #84