### PR TITLE
fix(chat): do not check player count during server start-up on Discord messages (fixes #84) (#91)

### DIFF
--- a/minecord-chat/src/main/java/me/axieum/mcmod/minecord/impl/chat/util/MinecraftDispatcher.java
+++ b/minecord-chat/src/main/java/me/axieum/mcmod/minecord/impl/chat/util/MinecraftDispatcher.java
@@ -99,7 +99,9 @@ public final class MinecraftDispatcher
     )
     {
         // Fetch the Minecraft server instance, only if there is at least one player logged in
-        Minecord.getInstance().getMinecraft().filter(server -> server.getCurrentPlayerCount() > 0).ifPresent(server ->
+        Minecord.getInstance().getMinecraft().filter(server ->
+            server.getPlayerManager() != null && server.getCurrentPlayerCount() > 0
+        ).ifPresent(server ->
             // Prepare a stream of configured chat entries
             Arrays.stream(getConfig().entries)
                   .parallel()


### PR DESCRIPTION
Backport to Minecraft 1.19.4

(cherry picked from commit 8cddbeb844f9d20d996dcc0137209e7198bdaa81)